### PR TITLE
Fix: Adjust pending alarms on timezone change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,9 +51,11 @@
         <receiver
             android:name=".alarm.BootReceiver"
             android:enabled="true"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/uvayankee/medreminder/alarm/AlarmRepository.kt
+++ b/app/src/main/java/com/uvayankee/medreminder/alarm/AlarmRepository.kt
@@ -20,6 +20,41 @@ class AlarmRepository(
         alarmScheduler.triggerImmediateNotificationUpdate()
     }
 
+    suspend fun adjustAlarmsForTimezoneChange() {
+        Log.i("AlarmRepository", "Adjusting pending alarms for timezone change")
+        val pendingDoses = alarmDao.getAllPendingAndSnoozedDoses().filter { it.status == DoseStatus.PENDING }
+        for (dose in pendingDoses) {
+            val rem = dose.reminderTimeMinutes * 60000L
+            val x = dose.scheduledTime - rem
+            val d = Math.round(x.toDouble() / 86400000.0)
+
+            val utcCal = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+                timeInMillis = d * 86400000L
+            }
+            val year = utcCal.get(Calendar.YEAR)
+            val month = utcCal.get(Calendar.MONTH)
+            val day = utcCal.get(Calendar.DAY_OF_MONTH)
+
+            val newCal = Calendar.getInstance().apply {
+                set(Calendar.YEAR, year)
+                set(Calendar.MONTH, month)
+                set(Calendar.DAY_OF_MONTH, day)
+                set(Calendar.HOUR_OF_DAY, dose.reminderTimeMinutes / 60)
+                set(Calendar.MINUTE, dose.reminderTimeMinutes % 60)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+
+            val newScheduledTime = newCal.timeInMillis
+            if (newScheduledTime != dose.scheduledTime) {
+                alarmDao.updateDoseLog(dose.copy(scheduledTime = newScheduledTime))
+                Log.i("AlarmRepository", "Adjusted dose ${dose.id} for timezone change: ${dose.scheduledTime} -> $newScheduledTime")
+            }
+        }
+
+        generateFutureDosesForAll()
+    }
+
     suspend fun generateUpcomingDosesForPrescription(pId: Long) {
         Log.i("AlarmRepository", "generateUpcomingDosesForPrescription: pId=$pId")
         alarmDao.clearPendingDosesForPrescription(pId)

--- a/app/src/main/java/com/uvayankee/medreminder/alarm/BootReceiver.kt
+++ b/app/src/main/java/com/uvayankee/medreminder/alarm/BootReceiver.kt
@@ -13,11 +13,16 @@ class BootReceiver : BroadcastReceiver(), KoinComponent {
     private val alarmRepository: AlarmRepository by inject()
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+        val action = intent.action
+        if (action == Intent.ACTION_BOOT_COMPLETED ||
+            action == Intent.ACTION_TIMEZONE_CHANGED ||
+            action == Intent.ACTION_TIME_CHANGED) {
             val scope = CoroutineScope(Dispatchers.IO)
             scope.launch {
-                // Re-calculate and schedule the next alarm after reboot
-                alarmRepository.scheduleInitialAlarms()
+                alarmRepository.adjustAlarmsForTimezoneChange()
+                if (action == Intent.ACTION_BOOT_COMPLETED) {
+                    alarmRepository.scheduleInitialAlarms()
+                }
             }
         }
     }

--- a/app/src/main/java/com/uvayankee/medreminder/db/AlarmDao.kt
+++ b/app/src/main/java/com/uvayankee/medreminder/db/AlarmDao.kt
@@ -93,4 +93,7 @@ interface AlarmDao {
     @Transaction
     @Query("SELECT * FROM dose_log WHERE status = 'PENDING' OR status = 'SNOOZED' ORDER BY scheduledTime ASC")
     fun getPendingDosesFlow(): Flow<List<DoseLog>>
+
+    @Query("SELECT * FROM dose_log WHERE status = 'PENDING' OR status = 'SNOOZED'")
+    suspend fun getAllPendingAndSnoozedDoses(): List<DoseLog>
 }

--- a/app/src/test/java/com/uvayankee/medreminder/TimezoneJumpTest.kt
+++ b/app/src/test/java/com/uvayankee/medreminder/TimezoneJumpTest.kt
@@ -1,0 +1,102 @@
+package com.uvayankee.medreminder
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.uvayankee.medreminder.alarm.AlarmRepository
+import com.uvayankee.medreminder.alarm.AlarmScheduler
+import com.uvayankee.medreminder.db.*
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.stopKoin
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+import java.util.TimeZone
+
+@RunWith(RobolectricTestRunner::class)
+class TimezoneJumpTest {
+    private lateinit var db: AppDatabase
+    private lateinit var alarmDao: AlarmDao
+    private lateinit var alarmRepository: AlarmRepository
+    private var defaultTz: TimeZone? = null
+
+    @Before
+    fun createDb() {
+        stopKoin()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).allowMainThreadQueries().build()
+        alarmDao = db.alarmDao()
+        alarmRepository = AlarmRepository(alarmDao, AlarmScheduler(context))
+        defaultTz = TimeZone.getDefault()
+    }
+
+    @After
+    fun closeDb() {
+        db.close()
+        stopKoin()
+        defaultTz?.let { TimeZone.setDefault(it) }
+    }
+
+    @Test
+    fun testTimezoneJumpOverAlarm() = runBlocking {
+        // Start in America/Denver (MT)
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Denver"))
+        val pId = alarmDao.insertPrescription(Prescription(name = "Med", startDate = 0, endDate = Long.MAX_VALUE))
+
+        // Alarm at 2:00 PM (14 * 60 = 840 minutes)
+        val timeMinutes = 840
+        val cal = Calendar.getInstance().apply {
+            set(Calendar.YEAR, 2026)
+            set(Calendar.MONTH, Calendar.MAY)
+            set(Calendar.DAY_OF_MONTH, 2)
+            set(Calendar.HOUR_OF_DAY, 14)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        val origTime = cal.timeInMillis
+
+        val doseId = alarmDao.insertDoseLog(DoseLog(
+            prescriptionId = pId,
+            scheduledTime = origTime,
+            reminderTimeMinutes = timeMinutes,
+            status = DoseStatus.PENDING
+        ))
+
+        // Timezone changes to America/Chicago (CT) at 1:30 PM MT (which is 2:30 PM CT)
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Chicago"))
+
+        alarmRepository.adjustAlarmsForTimezoneChange()
+
+        val dose = alarmDao.getDoseById(doseId)!!
+
+        // The scheduled time should still represent 2:00 PM local time in CT
+        val newCal = Calendar.getInstance().apply { timeInMillis = dose.scheduledTime }
+        assertEquals(14, newCal.get(Calendar.HOUR_OF_DAY))
+        assertEquals(0, newCal.get(Calendar.MINUTE))
+        assertEquals(840, dose.reminderTimeMinutes)
+
+        // Now, we simulate "now" being 2:30 PM CT
+        val nowCal = Calendar.getInstance().apply {
+            set(Calendar.YEAR, 2026)
+            set(Calendar.MONTH, Calendar.MAY)
+            set(Calendar.DAY_OF_MONTH, 2)
+            set(Calendar.HOUR_OF_DAY, 14)
+            set(Calendar.MINUTE, 30)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        val now = nowCal.timeInMillis
+
+        // Since scheduledTime is 2:00 PM CT and now is 2:30 PM CT, it should be considered overdue
+        val overdueDoses = alarmDao.getOverdueDoses(now)
+        assertTrue(overdueDoses.any { it.id == doseId })
+    }
+}

--- a/app/src/test/java/com/uvayankee/medreminder/TimezoneTest.kt
+++ b/app/src/test/java/com/uvayankee/medreminder/TimezoneTest.kt
@@ -1,0 +1,86 @@
+package com.uvayankee.medreminder
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.uvayankee.medreminder.alarm.AlarmRepository
+import com.uvayankee.medreminder.alarm.AlarmScheduler
+import com.uvayankee.medreminder.db.*
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.stopKoin
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+import java.util.TimeZone
+
+@RunWith(RobolectricTestRunner::class)
+class TimezoneTest {
+    private lateinit var db: AppDatabase
+    private lateinit var alarmDao: AlarmDao
+    private lateinit var alarmRepository: AlarmRepository
+    private var defaultTz: TimeZone? = null
+
+    @Before
+    fun createDb() {
+        stopKoin()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).allowMainThreadQueries().build()
+        alarmDao = db.alarmDao()
+        alarmRepository = AlarmRepository(alarmDao, AlarmScheduler(context))
+        defaultTz = TimeZone.getDefault()
+    }
+
+    @After
+    fun closeDb() {
+        db.close()
+        stopKoin()
+        defaultTz?.let { TimeZone.setDefault(it) }
+    }
+
+    @Test
+    fun testTimezoneChangeAdjustsDoseTime() = runBlocking {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Denver")) // MDT/MST
+        val pId = alarmDao.insertPrescription(Prescription(name = "Med", startDate = 0, endDate = Long.MAX_VALUE))
+
+        // Let's say we set an alarm for 6:30 PM (18 * 60 + 30 = 1110 minutes)
+        val timeMinutes = 1110
+        val cal = Calendar.getInstance().apply {
+            set(Calendar.YEAR, 2026)
+            set(Calendar.MONTH, Calendar.MAY)
+            set(Calendar.DAY_OF_MONTH, 2)
+            set(Calendar.HOUR_OF_DAY, 18)
+            set(Calendar.MINUTE, 30)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        val origTime = cal.timeInMillis
+
+        val doseId = alarmDao.insertDoseLog(DoseLog(
+            prescriptionId = pId,
+            scheduledTime = origTime,
+            reminderTimeMinutes = timeMinutes,
+            status = DoseStatus.PENDING
+        ))
+
+        // Change to Central Time
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Chicago"))
+
+        alarmRepository.adjustAlarmsForTimezoneChange()
+
+        val dose = alarmDao.getDoseById(doseId)!!
+        assertNotEquals(origTime, dose.scheduledTime)
+
+        // It should still be 6:30 PM local time in the new timezone
+        val newCal = Calendar.getInstance().apply { timeInMillis = dose.scheduledTime }
+        assertEquals(18, newCal.get(Calendar.HOUR_OF_DAY))
+        assertEquals(30, newCal.get(Calendar.MINUTE))
+        assertEquals(1110, dose.reminderTimeMinutes)
+    }
+}


### PR DESCRIPTION
Fixes #34 by dynamically adjusting the UTC `scheduledTime` of all pending doses whenever the device's timezone (or time) changes, maintaining the original local time for the dose reminders. Also updates the BootReceiver and manifest to listen to the relevant intent broadcasts.

---
*PR created automatically by Jules for task [3278837513054927470](https://jules.google.com/task/3278837513054927470) started by @uvayankee*