### PR TITLE
Feat: Resync Alarms admin button to resolve timezone corruption

### DIFF
--- a/.gemini/plans/resync-alarms.md
+++ b/.gemini/plans/resync-alarms.md
@@ -1,0 +1,66 @@
+# Resync Alarms Implementation Plan
+
+## Objective
+Add a "Resync Alarms" options menu button to the main screen. This will serve as an "admin button" to clean up and regenerate all future alarms, resolving the corrupted schedules caused by a previous timezone bug.
+
+## Key Files & Context
+*   `app/src/main/java/com/uvayankee/medreminder/db/AlarmDao.kt`: Needs a query to delete all future-facing doses.
+*   `app/src/main/java/com/uvayankee/medreminder/alarm/AlarmRepository.kt`: Needs a method to orchestrate the global deletion and regeneration.
+*   `app/src/main/java/com/uvayankee/medreminder/presentation/MainViewModel.kt`: Needs to expose the resync action to the UI.
+*   `app/src/main/java/com/uvayankee/medreminder/MainActivity.kt`: Needs to implement the Options Menu.
+*   `app/src/main/res/menu/main_menu.xml`: New file to define the menu item.
+
+## Implementation Steps
+
+1.  **Database Level (`AlarmDao.kt`)**
+    *   Add a new method:
+        ```kotlin
+        @Query("DELETE FROM dose_log WHERE status = 'PENDING' OR status = 'SNOOZED'")
+        suspend fun clearAllPendingAndSnoozedDoses()
+        ```
+
+2.  **Repository Level (`AlarmRepository.kt`)**
+    *   Add a new method `resyncAllAlarms()`:
+        ```kotlin
+        suspend fun resyncAllAlarms() {
+            Log.i("AlarmRepository", "Resyncing all alarms globally")
+            alarmDao.clearAllPendingAndSnoozedDoses()
+            val prescriptions = alarmDao.getActivePrescriptions()
+            prescriptions.forEach {
+                ensureFutureDosesScheduled(it.id, force = true)
+            }
+            refreshNotifications()
+        }
+        ```
+
+3.  **ViewModel Level (`MainViewModel.kt`)**
+    *   Add a function to launch the repository action:
+        ```kotlin
+        fun resyncAlarms() {
+            viewModelScope.launch {
+                alarmRepository.resyncAllAlarms()
+            }
+        }
+        ```
+
+4.  **UI Resources (`res/menu/main_menu.xml`)**
+    *   Create the menu file with a single item:
+        ```xml
+        <?xml version="1.0" encoding="utf-8"?>
+        <menu xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto">
+            <item
+                android:id="@+id/action_resync"
+                android:title="Resync Alarms"
+                app:showAsAction="never" />
+        </menu>
+        ```
+
+5.  **UI Activity (`MainActivity.kt`)**
+    *   Override `onCreateOptionsMenu` to inflate the menu.
+    *   Override `onOptionsItemSelected` to handle the action, call `viewModel.resyncAlarms()`, and show a Toast message ("Alarms resynchronized").
+
+## Verification
+*   Compile and run the app.
+*   Click the 3-dot menu and select "Resync Alarms".
+*   Verify that duplicate/corrupted doses on the Schedule tab are replaced with a single correct timeline.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,6 +25,7 @@
 *   **Safety Window:** Implemented a 30-minute buffer; doses more than 30 minutes in the future require a confirmation dialog to "Take Early" to prevent accidental misuse.
 
 ## Technical Improvements & Bug Fixes
+*   **Timezone Resilience:** Added a `TimezoneReceiver` that automatically recalculates and reschedules all pending alarms when the device's timezone or system time changes, ensuring medication reminders remain accurate during travel.
 *   **Room Migration:** Modernized the legacy SQLite schema into a clean Room database structure (currently at version 2).
 *   **Koin DI:** implemented dependency injection for Repositories, DAOs, and Utilities.
 *   **Unit Testing:** Added a suite of Robolectric tests in `app/src/test` to verify scheduling logic and prevent regressions.
@@ -32,7 +33,7 @@
 *   **Loop Fix:** Resolved an issue where overdue doses caused the notification sound to fire every 10 seconds by switching to a more precise "Future-only" scheduling query.
 
 ## Current State
-*   **Building:** Successfully compiles with Java 17 and Gradle 8.9.
+*   **Building:** Successfully compiles with Java 21 (required for KSP/Kotlin compatibility) and Gradle 9.1.0.
 *   **Reliability:** The "chain" is extended for 7 days every time a prescription is saved or an alarm fires.
 *   **Permissions:** Properly handles Android 13+ Notification permissions and Android 12+ Exact Alarm permissions.
 

--- a/app/src/main/java/com/uvayankee/medreminder/MainActivity.kt
+++ b/app/src/main/java/com/uvayankee/medreminder/MainActivity.kt
@@ -18,6 +18,8 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import android.view.Menu
+import android.view.MenuItem
 import com.google.android.material.tabs.TabLayout
 import com.uvayankee.medreminder.databinding.ActivityMainBinding
 import com.uvayankee.medreminder.databinding.ItemDateBinding
@@ -60,6 +62,22 @@ class MainActivity : AppCompatActivity() {
         setupUI()
         checkPermissions()
         observeUiState()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_resync -> {
+                viewModel.resyncAlarms()
+                Toast.makeText(this, "Alarms resynchronized", Toast.LENGTH_SHORT).show()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     private fun setupUI() {

--- a/app/src/main/java/com/uvayankee/medreminder/alarm/AlarmRepository.kt
+++ b/app/src/main/java/com/uvayankee/medreminder/alarm/AlarmRepository.kt
@@ -20,6 +20,16 @@ class AlarmRepository(
         alarmScheduler.triggerImmediateNotificationUpdate()
     }
 
+    suspend fun resyncAllAlarms() {
+        Log.i("AlarmRepository", "Resyncing all alarms globally")
+        alarmDao.clearAllPendingAndSnoozedDoses()
+        val prescriptions = alarmDao.getActivePrescriptions()
+        prescriptions.forEach {
+            ensureFutureDosesScheduled(it.id, force = true)
+        }
+        refreshNotifications()
+    }
+
     suspend fun adjustAlarmsForTimezoneChange() {
         Log.i("AlarmRepository", "Adjusting pending alarms for timezone change")
         val pendingDoses = alarmDao.getAllPendingAndSnoozedDoses().filter { it.status == DoseStatus.PENDING }

--- a/app/src/main/java/com/uvayankee/medreminder/db/AlarmDao.kt
+++ b/app/src/main/java/com/uvayankee/medreminder/db/AlarmDao.kt
@@ -96,4 +96,7 @@ interface AlarmDao {
 
     @Query("SELECT * FROM dose_log WHERE status = 'PENDING' OR status = 'SNOOZED'")
     suspend fun getAllPendingAndSnoozedDoses(): List<DoseLog>
+
+    @Query("DELETE FROM dose_log WHERE status = 'PENDING' OR status = 'SNOOZED'")
+    suspend fun clearAllPendingAndSnoozedDoses()
 }

--- a/app/src/main/java/com/uvayankee/medreminder/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/uvayankee/medreminder/presentation/MainViewModel.kt
@@ -133,4 +133,10 @@ class MainViewModel(
             deletePrescriptionUseCase(prescription)
         }
     }
+
+    fun resyncAlarms() {
+        viewModelScope.launch {
+            alarmRepository.resyncAllAlarms()
+        }
+    }
 }

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_resync"
+        android:title="Resync Alarms"
+        app:showAsAction="never" />
+</menu>


### PR DESCRIPTION
Closes #36.

This PR adds a manual Resync Alarms option to the main screen's overflow menu. This allows users to purge and regenerate their entire future schedule horizon, which is necessary if previous timezone transitions caused duplicate or shifted alarms in the database.

- Added clearAllPendingAndSnoozedDoses to AlarmDao.
- Added resyncAllAlarms to AlarmRepository.
- Added options menu to MainActivity.